### PR TITLE
Add tier system to loot table and crate contents

### DIFF
--- a/addons/sourcemod/configs/royale/global.cfg
+++ b/addons/sourcemod/configs/royale/global.cfg
@@ -18,7 +18,7 @@
 		// Default values for all crates
 		"model"		"models/props_2fort/miningcrate002.mdl"
 		"skin"		"0"
-		"sound"		")ui/itemcrate_smash_ultrarare_short.wav"
+		"sound"		")ui/itemcrate_smash_rare.wav"
 		"health"	"125"
 		"contents"
 		{
@@ -99,7 +99,8 @@
 		// Special loot crate dropped from bus
 		
 		"model"		"models/props_lakeside/wood_crate_01.mdl"
-		"health"	"225"
+		"sound"		")ui/itemcrate_smash_ultrarare_short.wav"
+		"health"	"250"
 		"mass"		"10.0"
 		"impact"	"2.0"
 		"contents"

--- a/addons/sourcemod/configs/royale/global.cfg
+++ b/addons/sourcemod/configs/royale/global.cfg
@@ -24,50 +24,79 @@
 		{
 			"content"
 			{
-				"type"		"WEAPON_COMMON"
-				"frequency"	"20"
+				"type"			"weapon"
+				"tier"			"1"
+				"percentage"	"1.0"
 			}
 			"content"
 			{
-				"type"		"WEAPON_UNCOMMON"
-				"frequency"	"10"
+				"type"			"weapon"
+				"tier"			"2"
+				"percentage"	"0.75"
 			}
 			"content"
 			{
-				"type"		"WEAPON_RARE"
-				"frequency"	"7"
+				"type"			"weapon"
+				"tier"			"3"
+				"percentage"	"0.5"
+			}
+			
+			"content"
+			{
+				"type"			"spell_pickup"
+				"tier"			"1"
+				"percentage"	"0.25"
 			}
 			"content"
 			{
-				"type"		"WEAPON_MISC"
-				"frequency"	"2"
+				"type"			"spell_pickup"
+				"tier"			"2"
+				"percentage"	"0.1"
+			}
+			
+			"content"
+			{
+				"type"			"item_healthkit"
+				"tier"			"1"
+				"percentage"	"0.5"
 			}
 			"content"
 			{
-				"type"		"PICKUP_SPELL"
-				"frequency"	"2"
+				"type"			"item_healthkit"
+				"tier"			"2"
+				"percentage"	"0.25"
 			}
 			"content"
 			{
-				"type"		"PICKUP_HEALTH"
-				"frequency"	"4"
+				"type"			"item_healthkit"
+				"tier"			"3"
+				"percentage"	"0.1"
+			}
+			
+			"content"
+			{
+				"type"			"item_ammopack"
+				"tier"			"1"
+				"percentage"	"0.5"
 			}
 			"content"
 			{
-				"type"		"PICKUP_AMMO"
-				"frequency"	"2"
+				"type"			"item_ammopack"
+				"tier"			"2"
+				"percentage"	"0.25"
 			}
 			"content"
 			{
-				"type"		"POWERUP_CRITS|POWERUP_UBER"
-				"frequency"	"1"
+				"type"			"item_ammopack"
+				"tier"			"3"
+				"percentage"	"0.1"
 			}
 		}
 	}
 	
 	"LootBus"
 	{
-		// Loot crate dropped from bus
+		// Special loot crate dropped from bus
 		
 		"model"		"models/props_lakeside/wood_crate_01.mdl"
 		"health"	"225"
@@ -77,75 +106,15 @@
 		{
 			"content"
 			{
-				"type"		"POWERUP_RUNE"
+				"type"			"item_powerup"
+				"tier"			"1"
+				"percentage"	"1.0"
 			}
-		}
-	}
-	
-	"LootPrefabs"
-	{
-		// List of prefabs for all maps
-		
-		"LootPrefab"
-		{
-			"name"		"AllWeapons"
-			"contents"
+			"content"
 			{
-					"content"
-				{
-					"type"		"WEAPON_COMMON"
-					"frequency"	"20"
-				}
-				"content"
-				{
-					"type"		"WEAPON_UNCOMMON"
-					"frequency"	"10"
-				}
-				"content"
-				{
-					"type"		"WEAPON_RARE"
-					"frequency"	"7"
-				}
-				"content"
-				{
-					"type"		"WEAPON_MISC"
-					"frequency"	"2"
-				}
-			}
-		}
-		
-		"LootPrefab"
-		{
-			"name"		"AllPickups"
-			"contents"
-			{
-				"content"
-				{
-					"type"		"PICKUP_SPELL"
-					"frequency"	"2"
-				}
-				"content"
-				{
-					"type"		"PICKUP_HEALTH"
-					"frequency"	"4"
-				}
-				"content"
-				{
-					"type"		"PICKUP_AMMO"
-					"frequency"	"2"
-				}
-			}
-		}
-		
-		"LootPrefab"
-		{
-			"name"		"AllPowerups"
-			"contents"
-			{
-				"content"
-				{
-					"type"		"POWERUP_CRITS|POWERUP_UBER"
-				}
+				"type"			"item_powerup"
+				"tier"			"2"
+				"percentage"	"0.75"
 			}
 		}
 	}

--- a/addons/sourcemod/configs/royale/loot.cfg
+++ b/addons/sourcemod/configs/royale/loot.cfg
@@ -9,7 +9,8 @@
 	
 	"Loot"	// B.A.S.E. Jumper
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"callback_precache"	"LootCallback_PrecacheWeapon"
@@ -31,7 +32,8 @@
 	
 	"Loot"	// Pistol
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -52,7 +54,8 @@
 	
 	"Loot"	// Shotgun
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -73,7 +76,8 @@
 	
 	"Loot"	// Reserve Shooter
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -88,7 +92,8 @@
 	
 	"Loot"	// Panic Attack
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -103,7 +108,8 @@
 	
 	"Loot"	// Pain Train
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -118,7 +124,8 @@
 	
 	"Loot"	// Half-Zatoichi
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -135,7 +142,8 @@
 	
 	"Loot"	// Scattergun
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -156,7 +164,8 @@
 	
 	"Loot"	// Force-A-Nature
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -177,7 +186,8 @@
 	
 	"Loot"	// Shortstop
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -192,7 +202,8 @@
 	
 	"Loot"	// Soda Popper
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -207,7 +218,8 @@
 	
 	"Loot"	// Baby Face's Blaster
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -222,7 +234,8 @@
 	
 	"Loot"	// Back Scatter
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -239,7 +252,8 @@
 	
 	"Loot"	// Bonk! Atomic Punch
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -260,7 +274,8 @@
 	
 	"Loot"	// Crit-a-Cola
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -275,7 +290,8 @@
 	
 	"Loot"	// Mad Milk
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -290,7 +306,8 @@
 	
 	"Loot"	// Winger
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -305,7 +322,8 @@
 	
 	"Loot"	// Pretty Boy's Pocket Pistol
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -320,7 +338,8 @@
 	
 	"Loot"	// Flying Guillotine
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -343,7 +362,8 @@
 	
 	"Loot"	// Bat
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -364,7 +384,8 @@
 	
 	"Loot"	// Sandman
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -379,7 +400,8 @@
 	
 	"Loot"	// Holy Mackerel
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -400,7 +422,8 @@
 	
 	"Loot"	// Candy Cane
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -415,7 +438,8 @@
 	
 	"Loot"	// Boston Basher
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -436,7 +460,8 @@
 	
 	"Loot"	// Sun-on-a-Stick
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -451,7 +476,8 @@
 	
 	"Loot"	// Fan O'War
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -466,7 +492,8 @@
 	
 	"Loot"	// Atomizer
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -481,7 +508,8 @@
 	
 	"Loot"	// Wrap Assassin
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -498,7 +526,8 @@
 	
 	"Loot"	// Rocket Launcher
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -519,7 +548,8 @@
 	
 	"Loot"	// Direct Hit
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -534,7 +564,8 @@
 	
 	"Loot"	// Black Box
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -555,7 +586,8 @@
 	
 	"Loot"	// Rocket Jumper
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -570,7 +602,8 @@
 	
 	"Loot"	// Liberty Launcher
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -585,7 +618,8 @@
 	
 	"Loot"	// Cow Mangler 5000
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -600,7 +634,8 @@
 	
 	"Loot"	// Original
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -615,7 +650,8 @@
 	
 	"Loot"	// Beggar's Bazooka
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -630,7 +666,8 @@
 	
 	"Loot"	// Air Strike
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -647,7 +684,8 @@
 	
 	"Loot"	// Buff Banner
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -668,7 +706,8 @@
 	
 	"Loot"	// Gunboats
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"callback_precache"	"LootCallback_PrecacheWeapon"
@@ -689,7 +728,8 @@
 	
 	"Loot"	// Battalion's Backup
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -704,7 +744,8 @@
 	
 	"Loot"	// Concheror
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -719,7 +760,8 @@
 	
 	"Loot"	// Righteous Bison
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -734,7 +776,8 @@
 	
 	"Loot"	// Mantreads
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -751,7 +794,8 @@
 	
 	"Loot"	// Shovel
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -772,7 +816,8 @@
 	
 	"Loot"	// Equalizer
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -787,7 +832,8 @@
 	
 	"Loot"	// Market Gardener
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -802,7 +848,8 @@
 	
 	"Loot"	// Disciplinary Action
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -817,7 +864,8 @@
 	
 	"Loot"	// Escape Plan
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -834,7 +882,8 @@
 	
 	"Loot"	// Flame Thrower
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -855,7 +904,8 @@
 	
 	"Loot"	// Backburner
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -876,7 +926,8 @@
 	
 	"Loot"	// Degreaser
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -891,7 +942,8 @@
 	
 	"Loot"	// Phlogistinator
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -906,7 +958,8 @@
 	
 	"Loot"	// Rainblower
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -921,7 +974,8 @@
 	
 	"Loot"	// Dragon's Fury
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -938,7 +992,8 @@
 	
 	"Loot"	// Flare Gun
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -959,7 +1014,8 @@
 	
 	"Loot"	// Detonator
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -974,7 +1030,8 @@
 	
 	"Loot"	// Manmelter
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -989,7 +1046,8 @@
 	
 	"Loot"	// Scorch Shot
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1004,7 +1062,8 @@
 	
 	"Loot"	// Thermal Thruster
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1019,7 +1078,8 @@
 	
 	"Loot"	// Gas Passer
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1036,7 +1096,8 @@
 	
 	"Loot"	// Fire Axe
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1057,7 +1118,8 @@
 	
 	"Loot"	// Axtinguisher
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1078,7 +1140,8 @@
 	
 	"Loot"	// Homewrecker
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1099,7 +1162,8 @@
 	
 	"Loot"	// Powerjack
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1114,7 +1178,8 @@
 	
 	"Loot"	// Back Scratcher
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1129,7 +1194,8 @@
 	
 	"Loot"	// Sharpened Volcano Fragment
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1144,7 +1210,8 @@
 	
 	"Loot"	// Third Degree
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1159,7 +1226,8 @@
 	
 	"Loot"	// Neon Annihilator
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1174,7 +1242,8 @@
 	
 	"Loot"	// Hot Hand
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1191,7 +1260,8 @@
 	
 	"Loot"	// Grenade Launcher
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1212,7 +1282,8 @@
 	
 	"Loot"	// Loch-n-Load
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1227,7 +1298,8 @@
 	
 	"Loot"	// Ali Baba's Wee Booties
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1242,7 +1314,8 @@
 	
 	"Loot"	// Bootlegger
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1257,7 +1330,8 @@
 	
 	"Loot"	// Loose Cannon
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1272,7 +1346,8 @@
 	
 	"Loot"	// Iron Bomber
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1289,7 +1364,8 @@
 	
 	"Loot"	// Stickybomb Launcher
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1310,7 +1386,8 @@
 	
 	"Loot"	// Scottish Resistance
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1325,7 +1402,8 @@
 	
 	"Loot"	// Chargin' Targe
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1340,7 +1418,8 @@
 	
 	"Loot"	// Sticky Jumper
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1355,7 +1434,8 @@
 	
 	"Loot"	// Splendid Screen
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1370,7 +1450,8 @@
 	
 	"Loot"	// Tide Turner
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1385,7 +1466,8 @@
 	
 	"Loot"	// Quickiebomb Launcher
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1402,7 +1484,8 @@
 	
 	"Loot"	// Bottle
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1423,7 +1506,8 @@
 	
 	"Loot"	// Eyelander
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1444,7 +1528,8 @@
 	
 	"Loot"	// Scotsman's Skullcutter
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1459,7 +1544,8 @@
 	
 	"Loot"	// Ullapool Caber
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1474,7 +1560,8 @@
 	
 	"Loot"	// Claidheamh Mòr
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1489,7 +1576,8 @@
 	
 	"Loot"	// Persian Persuader
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1506,7 +1594,8 @@
 	
 	"Loot"	// Minigun
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1527,7 +1616,8 @@
 	
 	"Loot"	// Natascha
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1542,7 +1632,8 @@
 	
 	"Loot"	// Brass Beast
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1557,7 +1648,8 @@
 	
 	"Loot"	// Tomislav
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1572,7 +1664,8 @@
 	
 	"Loot"	// Huo-Long Heater
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1595,7 +1688,8 @@
 	
 	"Loot"	// Sandvich
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1616,7 +1710,8 @@
 	
 	"Loot"	// Dalokohs Bar
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1637,7 +1732,8 @@
 	
 	"Loot"	// Buffalo Steak Sandvich
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1652,7 +1748,8 @@
 	
 	"Loot"	// Family Business
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1667,7 +1764,8 @@
 	
 	"Loot"	// Second Banana
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1684,7 +1782,8 @@
 	
 	"Loot"	// Killing Gloves of Boxing
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1699,7 +1798,8 @@
 	
 	"Loot"	// Gloves of Running Urgently
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1720,7 +1820,8 @@
 	
 	"Loot"	// Warrior's Spirit
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1735,7 +1836,8 @@
 	
 	"Loot"	// Fists of Steel
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1750,7 +1852,8 @@
 	
 	"Loot"	// Eviction Notice
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1765,7 +1868,8 @@
 	
 	"Loot"	// Holiday Punch
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1782,7 +1886,8 @@
 	
 	"Loot"	// Frontier Justice
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1797,7 +1902,8 @@
 	
 	"Loot"	// Widowmaker
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1812,7 +1918,8 @@
 	
 	"Loot"	// Pomson 6000
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1827,7 +1934,8 @@
 	
 	"Loot"	// Rescue Ranger
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1842,7 +1950,8 @@
 	
 	"Loot"	// Panic Attack
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1859,7 +1968,8 @@
 	
 	"Loot"	// Wrangler
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1880,7 +1990,8 @@
 	
 	"Loot"	// Short Circuit
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1897,7 +2008,8 @@
 	
 	"Loot"	// Wrench
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1918,7 +2030,8 @@
 	
 	"Loot"	// Southern Hospitality
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1933,7 +2046,8 @@
 	
 	"Loot"	// Jag
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1948,7 +2062,8 @@
 	
 	"Loot"	// Eureka Effect
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1965,7 +2080,8 @@
 	
 	"Loot"	// Construction PDA
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1980,7 +2096,8 @@
 	
 	"Loot"	// Destruction PDA
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -1997,7 +2114,8 @@
 	
 	"Loot"	// Syringe Gun
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2018,7 +2136,8 @@
 	
 	"Loot"	// Blutsauger
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2033,7 +2152,8 @@
 	
 	"Loot"	// Crusader's Crossbow
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2054,7 +2174,8 @@
 	
 	"Loot"	// Overdose
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2071,7 +2192,8 @@
 	
 	"Loot"	// Medi Gun
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2092,7 +2214,8 @@
 	
 	"Loot"	// Kritzkrieg
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2107,7 +2230,8 @@
 	
 	"Loot"	// Quick-Fix
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2122,7 +2246,8 @@
 	
 	"Loot"	// Vaccinator
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2139,7 +2264,8 @@
 	
 	"Loot"	// Bonesaw
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2160,7 +2286,8 @@
 	
 	"Loot"	// Übersaw
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2181,7 +2308,8 @@
 	
 	"Loot"	// Vita-Saw
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2196,7 +2324,8 @@
 	
 	"Loot"	// Amputator
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2211,7 +2340,8 @@
 	
 	"Loot"	// Solemn Vow
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2228,7 +2358,8 @@
 	
 	"Loot"	// Sniper Rifle
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2249,7 +2380,8 @@
 	
 	"Loot"	// Huntsman
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2270,7 +2402,8 @@
 	
 	"Loot"	// Sydney Sleeper
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2285,7 +2418,8 @@
 	
 	"Loot"	// Bazaar Bargain
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2300,7 +2434,8 @@
 	
 	"Loot"	// Machina
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2321,7 +2456,8 @@
 	
 	"Loot"	// Hitman's Heatmaker
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2336,7 +2472,8 @@
 	
 	"Loot"	// Fortified Compound
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2351,7 +2488,8 @@
 	
 	"Loot"	// Classic
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2368,7 +2506,8 @@
 	
 	"Loot"	// SMG
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2389,7 +2528,8 @@
 	
 	"Loot"	// Razorback
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2404,7 +2544,8 @@
 	
 	"Loot"	// Jarate
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2425,7 +2566,8 @@
 	
 	"Loot"	// Darwin's Danger Shield
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2440,7 +2582,8 @@
 	
 	"Loot"	// Cozy Camper
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2455,7 +2598,8 @@
 	
 	"Loot"	// Cleaner's Carbine
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2472,7 +2616,8 @@
 	
 	"Loot"	// Kukri
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2493,7 +2638,8 @@
 	
 	"Loot"	// Tribalman's Shiv
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2508,7 +2654,8 @@
 	
 	"Loot"	// Bushwacka
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2523,7 +2670,8 @@
 	
 	"Loot"	// Shahanshah
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2540,7 +2688,8 @@
 	
 	"Loot"	// Revolver
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2561,7 +2710,8 @@
 	
 	"Loot"	// Ambassador
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2582,7 +2732,8 @@
 	
 	"Loot"	// L'Etranger
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2597,7 +2748,8 @@
 	
 	"Loot"	// Enforcer
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2612,7 +2764,8 @@
 	
 	"Loot"	// Diamondback
 	{
-		"type"		"WEAPON_COMMON"
+		"type"	"weapon"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2629,7 +2782,8 @@
 	
 	"Loot"	// Sapper
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2650,7 +2804,8 @@
 	
 	"Loot"	// Red Tape Recorder
 	{
-		"type"		"WEAPON_RARE"
+		"type"	"weapon"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"callback_precache"	"LootCallback_PrecacheWeapon"
@@ -2680,7 +2835,8 @@
 	
 	"Loot"	// Knife
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2701,7 +2857,8 @@
 	
 	"Loot"	// Your Eternal Reward
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2722,7 +2879,8 @@
 	
 	"Loot"	// Conniver's Kunai
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2737,7 +2895,8 @@
 	
 	"Loot"	// Big Earner
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2752,7 +2911,8 @@
 	
 	"Loot"	// Spy-cicle
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2769,7 +2929,8 @@
 	
 	"Loot"	// Invis Watch
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"callback_precache"	"LootCallback_PrecacheWeapon"
@@ -2791,7 +2952,8 @@
 	
 	"Loot"	// Dead Ringer
 	{
-		"type"		"WEAPON_UNCOMMON"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"callback_precache"	"LootCallback_PrecacheWeapon"
@@ -2815,7 +2977,8 @@
 	
 	"Loot"	// Grappling Hook
 	{
-		"type"		"WEAPON_MISC"
+		"type"	"weapon"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateWeapon"
 		"callback_class"	"LootCallback_ClassWeapon"
 		"params"
@@ -2830,7 +2993,8 @@
 	
 	"Loot"	// Small Health Kit
 	{
-		"type"		"PICKUP_HEALTH"
+		"type"	"item_healthkit"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateEntity"
 		"params"
 		{
@@ -2844,7 +3008,8 @@
 	
 	"Loot"	// Medium Health Kit
 	{
-		"type"		"PICKUP_HEALTH"
+		"type"	"item_healthkit"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateEntity"
 		"params"
 		{
@@ -2858,7 +3023,8 @@
 	
 	"Loot"	// Full Health Kit
 	{
-		"type"		"PICKUP_HEALTH"
+		"type"	"item_healthkit"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateEntity"
 		"params"
 		{
@@ -2872,7 +3038,8 @@
 	
 	"Loot"	// Small Ammo Pack
 	{
-		"type"		"PICKUP_AMMO"
+		"type"	"item_ammopack"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateEntity"
 		"params"
 		{
@@ -2886,7 +3053,8 @@
 	
 	"Loot"	// Medium Ammo Pack
 	{
-		"type"		"PICKUP_AMMO"
+		"type"	"item_ammopack"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateEntity"
 		"params"
 		{
@@ -2900,7 +3068,8 @@
 	
 	"Loot"	// Full Ammo Pack
 	{
-		"type"		"PICKUP_AMMO"
+		"type"	"item_ammopack"
+		"tier"	"3"
 		"callback_create"	"LootCallback_CreateEntity"
 		"params"
 		{
@@ -2914,7 +3083,8 @@
 	
 	"Loot"	// Common Spell
 	{
-		"type"		"PICKUP_SPELL"
+		"type"	"spell_pickup"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateSpell"
 		"params"
 		{
@@ -2928,7 +3098,8 @@
 	
 	"Loot"	// Rare Spell
 	{
-		"type"		"PICKUP_SPELL"
+		"type"	"spell_pickup"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateSpell"
 		"params"
 		{
@@ -2942,7 +3113,8 @@
 	
 	"Loot"	// Crits Powerup
 	{
-		"type"		"POWERUP_CRITS"
+		"type"	"item_powerup"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateEntity"
 		"params"
 		{
@@ -2956,7 +3128,8 @@
 	
 	"Loot"	// Uber Powerup
 	{
-		"type"		"POWERUP_UBER"
+		"type"	"item_powerup"
+		"tier"	"1"
 		"callback_create"	"LootCallback_CreateEntity"
 		"params"
 		{
@@ -2970,7 +3143,8 @@
 	
 	"Loot"	// Rune Powerup
 	{
-		"type"		"POWERUP_RUNE"
+		"type"	"item_powerup"
+		"tier"	"2"
 		"callback_create"	"LootCallback_CreateRune"
 	}
 }

--- a/addons/sourcemod/scripting/royale.sp
+++ b/addons/sourcemod/scripting/royale.sp
@@ -253,16 +253,11 @@ enum ETFGameType
  */
 enum LootType
 {
-	Loot_Weapon_Common = 0,		/**< Common weapons */
-	Loot_Weapon_Uncommon,		/**< Uncommon weapons */
-	Loot_Weapon_Rare,			/**< Rare weapons */
-	Loot_Weapon_Misc,			/**< Grappling Hook, etc. */
-	Loot_Pickup_Health,			/**< Health pickups */
-	Loot_Pickup_Ammo,			/**< Ammunition pickups */
-	Loot_Pickup_Spell,			/**< Halloween spells */
-	Loot_Powerup_Crits,			/**< Mannpower crit powerup */
-	Loot_Powerup_Uber,			/**< Mannpower uber powerup */
-	Loot_Powerup_Rune			/**< Mannpower rune powerup */
+	Loot_Weapon,			/**< Weapons */
+	Loot_Item_HealthKit,	/**< Health pickups */
+	Loot_Item_AmmoPack,		/**< Ammunition pickups */
+	Loot_Pickup_Spell,		/**< Halloween spell pickups */
+	Loot_Item_Powerup,		/**< Mannpower powerups */
 }
 
 char g_fistsClassname[][] = {

--- a/addons/sourcemod/scripting/royale/loot/loot.sp
+++ b/addons/sourcemod/scripting/royale/loot/loot.sp
@@ -3,16 +3,11 @@ static StringMap g_LootTypeMap;
 void Loot_Init()
 {
 	g_LootTypeMap = new StringMap();
-	g_LootTypeMap.SetValue("WEAPON_COMMON", Loot_Weapon_Common);
-	g_LootTypeMap.SetValue("WEAPON_UNCOMMON", Loot_Weapon_Uncommon);
-	g_LootTypeMap.SetValue("WEAPON_RARE", Loot_Weapon_Rare);
-	g_LootTypeMap.SetValue("WEAPON_MISC", Loot_Weapon_Misc);
-	g_LootTypeMap.SetValue("PICKUP_HEALTH", Loot_Pickup_Health);
-	g_LootTypeMap.SetValue("PICKUP_AMMO", Loot_Pickup_Ammo);
-	g_LootTypeMap.SetValue("PICKUP_SPELL", Loot_Pickup_Spell);
-	g_LootTypeMap.SetValue("POWERUP_CRITS", Loot_Powerup_Crits);
-	g_LootTypeMap.SetValue("POWERUP_UBER", Loot_Powerup_Uber);
-	g_LootTypeMap.SetValue("POWERUP_RUNE", Loot_Powerup_Rune);
+	g_LootTypeMap.SetValue("weapon", Loot_Weapon);
+	g_LootTypeMap.SetValue("item_healthkit", Loot_Item_HealthKit);
+	g_LootTypeMap.SetValue("item_ammopack", Loot_Item_AmmoPack);
+	g_LootTypeMap.SetValue("spell_pickup", Loot_Pickup_Spell);
+	g_LootTypeMap.SetValue("item_powerup", Loot_Item_Powerup);
 }
 
 void Loot_SpawnCratesInWorld()
@@ -78,19 +73,7 @@ void Loot_SetCratePrefab(int crate, LootCrate loot)
 	SetEntProp(crate, Prop_Data, "m_iHealth", loot.health);
 }
 
-ArrayList Loot_StrToLootTypes(const char[] str)
-{
-	ArrayList types = new ArrayList();
-	
-	char parts[32][PLATFORM_MAX_PATH];
-	int count = ExplodeString(str, "|", parts, sizeof(parts), sizeof(parts[]));
-	for (int i = 0; i < count; i++)
-		types.Push(Loot_StrToLootType(parts[i]));
-	
-	return types;
-}
-
-LootType Loot_StrToLootType(const char[] str)
+stock LootType Loot_StrToLootType(const char[] str)
 {
 	LootType type;
 	g_LootTypeMap.GetValue(str, type);
@@ -141,27 +124,37 @@ public void Loot_BreakCrate(int client, int crate, LootCrate loot)
 	if (0 < client <= MaxClients && IsClientInGame(client))
 		class = TF2_GetPlayerClass(client);
 	
-	//While loop to keep searching for loot until found valid
-	LootTable lootTable;
-	while (!LootTable_GetRandomLoot(lootTable, loot.GetRandomLootType(), class)) {  }
-	
-	float origin[3];
-	GetEntPropVector(crate, Prop_Data, "m_vecOrigin", origin);
-	
-	//Calculate where centre of origin by boundary box
-	float mins[3], maxs[3], offset[3];
-	GetEntPropVector(crate, Prop_Data, "m_vecMins", mins);
-	GetEntPropVector(crate, Prop_Data, "m_vecMaxs", maxs);
-	AddVectors(maxs, mins, offset);
-	ScaleVector(offset, 0.5);
-	AddVectors(origin, offset, origin);
-	
-	//Start function call to loot creation function
-	Call_StartFunction(null, lootTable.callback_create);
-	Call_PushCell(client);
-	Call_PushCell(lootTable.callbackParams);
-	Call_PushArray(origin, sizeof(origin));
-	
-	if (Call_Finish() != SP_ERROR_NONE)
-		LogError("Unable to call function for LootType '%d' class '%d'", lootTable.type, class);
+	//Search the contents table of this crate
+	LootCrateContent content;
+	while (loot.GetRandomLootCrateContent(content))
+	{
+		if (GetRandomFloat() <= content.percentage)
+		{
+			//Keep going until we find loot from the wanted type and tier
+			LootTable lootTable;
+			while (!LootTable_GetRandomLoot(lootTable, content.type, content.tier, class)) {  }
+			
+			float origin[3];
+			GetEntPropVector(crate, Prop_Data, "m_vecOrigin", origin);
+			
+			//Calculate where centre of origin by boundary box
+			float mins[3], maxs[3], offset[3];
+			GetEntPropVector(crate, Prop_Data, "m_vecMins", mins);
+			GetEntPropVector(crate, Prop_Data, "m_vecMaxs", maxs);
+			AddVectors(maxs, mins, offset);
+			ScaleVector(offset, 0.5);
+			AddVectors(origin, offset, origin);
+			
+			//Start function call to loot creation function
+			Call_StartFunction(null, lootTable.callback_create);
+			Call_PushCell(client);
+			Call_PushCell(lootTable.callbackParams);
+			Call_PushArray(origin, sizeof(origin));
+			
+			if (Call_Finish() != SP_ERROR_NONE)
+				LogError("Unable to call function for LootType '%d' class '%d'", lootTable.type, class);
+			
+			break;
+		}
+	}
 }

--- a/addons/sourcemod/scripting/royale/loot/loot_crates.sp
+++ b/addons/sourcemod/scripting/royale/loot/loot_crates.sp
@@ -72,8 +72,8 @@ enum struct LootCrate
 		kv.SetVector("angles", this.angles);
 	}
 	
-	bool GetRandomLootCrateContent(LootCrateContent buffer)
+	void GetRandomLootCrateContent(LootCrateContent buffer)
 	{
-		return this.contents.GetArray(GetRandomInt(0, this.contents.Length - 1), buffer, sizeof(buffer)) > 0;
+		this.contents.GetArray(GetRandomInt(0, this.contents.Length - 1), buffer, sizeof(buffer));
 	}
 }

--- a/addons/sourcemod/scripting/royale/loot/loot_crates.sp
+++ b/addons/sourcemod/scripting/royale/loot/loot_crates.sp
@@ -1,3 +1,10 @@
+enum struct LootCrateContent
+{
+	LootType type;
+	int tier;
+	float percentage;
+}
+
 enum struct LootCrate
 {
 	int entity; 					/**< Entity crate ref */
@@ -12,7 +19,7 @@ enum struct LootCrate
 	int skin;						/**< Model skin */
 	char sound[PLATFORM_MAX_PATH];	/**< Sound this crate emits when opening */
 	int health;						/**< Amount of damage required to open */
-	ArrayList contents;				/**< ArrayList of contents bitflags to select at random */
+	ArrayList contents;				/**< ArrayList of LootCrateContent */
 	
 	// LootBus
 	float mass;						/**< Crate mass */
@@ -31,25 +38,21 @@ enum struct LootCrate
 		
 		if (kv.JumpToKey("contents", false))
 		{
-			this.contents = new ArrayList();
+			this.contents = new ArrayList(sizeof(LootCrateContent));
 			if (kv.GotoFirstSubKey(false))
 			{
 				do
 				{
-					char type[PLATFORM_MAX_PATH];
+					LootCrateContent content;
+					
+					char type[64];
 					kv.GetString("type", type, sizeof(type));
+					content.type = Loot_StrToLootType(type);
 					
-					ArrayList types = Loot_StrToLootTypes(type);
-					int frequency = kv.GetNum("frequency", 1);
+					content.tier = kv.GetNum("tier", -1);
+					content.percentage = kv.GetFloat("percentage", 1.0);
 					
-					for (int i = 0; i < types.Length; i++)
-					{
-						LootType lootType = types.Get(i);
-						for (int j = 0; j < frequency; j++)
-							this.contents.Push(lootType);
-					}
-					
-					delete types;
+					this.contents.PushArray(content);
 				}
 				while (kv.GotoNextKey(false));
 				kv.GoBack();
@@ -69,8 +72,8 @@ enum struct LootCrate
 		kv.SetVector("angles", this.angles);
 	}
 	
-	LootType GetRandomLootType()
+	bool GetRandomLootCrateContent(LootCrateContent buffer)
 	{
-		return this.contents.Get(GetRandomInt(0, this.contents.Length - 1));
+		return this.contents.GetArray(GetRandomInt(0, this.contents.Length - 1), buffer, sizeof(buffer)) > 0;
 	}
 }

--- a/addons/sourcemod/scripting/royale/loot/loot_table.sp
+++ b/addons/sourcemod/scripting/royale/loot/loot_table.sp
@@ -125,7 +125,7 @@ void LootTable_ReadConfig(KeyValues kv)
 	kv.GoBack();
 }
 
-stock bool LootTable_GetRandomLoot(LootTable lootTable, LootType type, int tier, TFClassType class)
+bool LootTable_GetRandomLoot(LootTable lootTable, LootType type, int tier, TFClassType class)
 {
 	ArrayList list;
 	
@@ -157,8 +157,11 @@ stock bool LootTable_GetRandomLoot(LootTable lootTable, LootType type, int tier,
 		
 		LootTable temp;
 		for (int i = 0; i < list.Length; i++)
-			if (list.GetArray(i, temp, sizeof(temp)) > 0 && temp.tier == tier)
+		{
+			list.GetArray(i, temp, sizeof(temp));
+			if (temp.tier == tier)
 				loot.PushArray(temp, sizeof(temp));
+		}
 		
 		loot.GetArray(GetRandomInt(0, loot.Length - 1), lootTable, sizeof(lootTable));
 		delete loot;

--- a/addons/sourcemod/scripting/royale/loot/loot_table.sp
+++ b/addons/sourcemod/scripting/royale/loot/loot_table.sp
@@ -1,6 +1,7 @@
 enum struct LootTable
 {
 	LootType type;
+	int tier;
 	Function callback_create;
 	Function callback_class;
 	Function callback_precache;
@@ -28,6 +29,8 @@ void LootTable_ReadConfig(KeyValues kv)
 			char type[CONFIG_MAXCHAR];
 			kv.GetString("type", type, sizeof(type));
 			lootTable.type = Loot_StrToLootType(type);
+			
+			lootTable.tier = kv.GetNum("tier", -1);
 			
 			char callback[CONFIG_MAXCHAR];
 			kv.GetString("callback_create", callback, sizeof(callback), NULL_STRING);
@@ -122,7 +125,7 @@ void LootTable_ReadConfig(KeyValues kv)
 	kv.GoBack();
 }
 
-bool LootTable_GetRandomLoot(LootTable lootTable, LootType type, TFClassType class)
+stock bool LootTable_GetRandomLoot(LootTable lootTable, LootType type, int tier, TFClassType class)
 {
 	ArrayList list;
 	
@@ -143,6 +146,23 @@ bool LootTable_GetRandomLoot(LootTable lootTable, LootType type, TFClassType cla
 			return false;
 	}
 	
-	list.GetArray(GetRandomInt(0, list.Length - 1), lootTable, sizeof(lootTable));
+	if (tier == -1)
+	{
+		list.GetArray(GetRandomInt(0, list.Length - 1), lootTable, sizeof(lootTable));
+	}
+	else
+	{
+		//Collect all loot with the specified tier
+		ArrayList loot = new ArrayList(sizeof(LootTable));
+		
+		LootTable temp;
+		for (int i = 0; i < list.Length; i++)
+			if (list.GetArray(i, temp, sizeof(temp)) > 0 && temp.tier == tier)
+				loot.PushArray(temp, sizeof(temp));
+		
+		loot.GetArray(GetRandomInt(0, loot.Length - 1), lootTable, sizeof(lootTable));
+		delete loot;
+	}
+	
 	return true;
 }


### PR DESCRIPTION
- Add ``tier`` to loot table and crate contents
  - Different loot of the same type can now be differentiated using tiers
  - Crates can specify different chances for each loot type + tier combination
- Replaced ``frequency`` in crate contents with ``percentage`` to avoid storing the same information several times
- Merged several loot types in favor of tier system, such as ``WEAPON_COMMON``, ``WEAPON_UNCOMMON`` and ``WEAPON_RARE`` into ``weapon``
- Renamed loot types to stop making them look like they are still bit flags
- Drop support for multiple loot types separated by ``|`` in one content entry
