### PR TITLE
Grant spies wallhacks on disguise targets

### DIFF
--- a/addons/sourcemod/configs/royale/loot.cfg
+++ b/addons/sourcemod/configs/royale/loot.cfg
@@ -3,7 +3,6 @@
 	// Weapons that are NOT in the list (yet)
 	// - Fists
 	// - Gunslinger
-	// - Disguise Kit
 	
 	// Multiclass
 	
@@ -2926,6 +2925,22 @@
 	}
 	
 	// Spy - PDA
+	
+	"Loot"	// Disguise Kit
+	{
+		"type"	"weapon"
+		"tier"	"2"
+		"callback_create"	"LootCallback_CreateWeapon"
+		"callback_class"	"LootCallback_ClassWeapon"
+		"params"
+		{
+			"param"
+			{
+				"key"	"defindex"
+				"value"	"27"
+			}
+		}
+	}
 	
 	"Loot"	// Invis Watch
 	{

--- a/addons/sourcemod/scripting/royale.sp
+++ b/addons/sourcemod/scripting/royale.sp
@@ -713,6 +713,10 @@ public void TF2_OnConditionAdded(int client, TFCond condition)
 	//knockout dont get forced to melee if have fists as melee weapon (only works properly on heavy)
 	if (condition == TFCond_RuneKnockout)
 		TF2_SwitchActiveWeapon(client, TF2_GetItemInSlot(client, WeaponSlot_Melee));
+	
+	//Force disguises to be of your own team
+	if (condition == TFCond_Disguising)
+		SetEntProp(client, Prop_Send, "m_nDesiredDisguiseTeam", TF2_GetClientTeam(client));
 }
 
 public void TF2_OnConditionRemoved(int client, TFCond condition)

--- a/addons/sourcemod/scripting/royale/event.sp
+++ b/addons/sourcemod/scripting/royale/event.sp
@@ -120,6 +120,7 @@ public Action Event_PlayerSpawn(Event event, const char[] name, bool dontBroadca
 	if (TF2_GetClientTeam(client) <= TFTeam_Spectator)
 		return;
 	
+	TF2_CreateGlow(client);
 	TF2_CheckClientWeapons(client);
 	TFClassType class = TF2_GetPlayerClass(client);
 	


### PR DESCRIPTION
This adds the disguise kit to the crate drop table. Allows spies to disguise themselves as any enemy (in the same team). Since showing the actual disguise is impossible due to client-side shenanigans, it instead adds a glowing outline to the disguise target, granting spies a special "wall-hack" ability.