### PR TITLE
Allow spawning during "Waiting for players"

### DIFF
--- a/addons/sourcemod/scripting/royale.sp
+++ b/addons/sourcemod/scripting/royale.sp
@@ -699,6 +699,16 @@ public void OnEntityDestroyed(int entity)
 	}
 }
 
+public void TF2_OnWaitingForPlayersStart()
+{
+	FindConVar("mp_disable_respawn_times").BoolValue = true;
+}
+
+public void TF2_OnWaitingForPlayersEnd()
+{
+	FindConVar("mp_disable_respawn_times").BoolValue = false;
+}
+
 public void TF2_OnConditionAdded(int client, TFCond condition)
 {
 	if (!g_Enabled)

--- a/addons/sourcemod/scripting/royale/console.sp
+++ b/addons/sourcemod/scripting/royale/console.sp
@@ -70,7 +70,7 @@ public Action Console_JoinTeam(int client, const char[] command, int args)
 		}
 	}
 	
-	if (IsPlayerAlive(client))
+	if (!GameRules_GetProp("m_bInWaitingForPlayers") && IsPlayerAlive(client))
 		return Plugin_Handled;
 	
 	//Force set client to dead team

--- a/addons/sourcemod/scripting/royale/console.sp
+++ b/addons/sourcemod/scripting/royale/console.sp
@@ -130,6 +130,9 @@ public Action Console_VoiceMenu(int client, const char[] command, int args)
 
 public Action Console_DropItem(int client, const char[] command, int args)
 {
+	if (GameRules_GetProp("m_bInWaitingForPlayers"))
+		return Plugin_Continue;
+	
 	if (!IsPlayerAlive(client))
 		return Plugin_Continue;
 	

--- a/addons/sourcemod/scripting/royale/convar.sp
+++ b/addons/sourcemod/scripting/royale/convar.sp
@@ -46,6 +46,7 @@ void ConVar_Init()
 	ConVar_Add("mp_forcecamera", 0.0);
 	ConVar_Add("mp_friendlyfire", 1.0);
 	ConVar_Add("mp_respawnwavetime", 99999.0);
+	ConVar_Add("mp_waitingforplayers_time", 60.0);
 	ConVar_Add("tf_avoidteammates", 0.0);
 	ConVar_Add("tf_dropped_weapon_lifetime", 99999.0);
 	ConVar_Add("tf_helpme_range", -1.0);

--- a/addons/sourcemod/scripting/royale/dhook.sp
+++ b/addons/sourcemod/scripting/royale/dhook.sp
@@ -516,12 +516,16 @@ public MRESReturn DHook_GetMaxHealthPost(int client, DHookReturn ret)
 
 public MRESReturn DHook_ForceRespawnPre(int client)
 {
+	//Enable Mannpower uber during waiting for players and allow RuneRegenThink to start
+	GameRules_SetProp("m_bPowerupMode", true);
+	
+	//Don't do all of our custom stuff during waiting for players
+	if (GameRules_GetProp("m_bInWaitingForPlayers"))
+		return MRES_Ignored;
+	
 	//Only allow respawn if player is in parachute mode
 	if (FRPlayer(client).PlayerState != PlayerState_Parachute)
 		return MRES_Supercede;
-	
-	//Allow RuneRegenThink to start
-	GameRules_SetProp("m_bPowerupMode", true);
 	
 	//If player havent selected a class, pick random class for em
 	//this is so that player can actually spawn into map, otherwise nothing happens

--- a/addons/sourcemod/scripting/royale/dhook.sp
+++ b/addons/sourcemod/scripting/royale/dhook.sp
@@ -365,8 +365,8 @@ public MRESReturn DHook_InSameTeamPre(int entity, DHookReturn ret, DHookParam pa
 
 public MRESReturn DHook_CreatePre(DHookReturn ret, DHookParam param)
 {
-	//Dont create any dropped weapon created by tf2 (TF2_CreateDroppedWeapon pass client param as NULL)
-	if (!param.IsNull(1))
+	//Don't create any dropped weapon created by TF2 (TF2_CreateDroppedWeapon passes client param as NULL)
+	if (!GameRules_GetProp("m_bInWaitingForPlayers") && !param.IsNull(1))
 	{
 		ret.Value = 0;
 		return MRES_Supercede;

--- a/addons/sourcemod/scripting/royale/event.sp
+++ b/addons/sourcemod/scripting/royale/event.sp
@@ -116,6 +116,9 @@ public Action Event_SetupFinished(Event event, const char[] name, bool dontBroad
 
 public Action Event_PlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 {
+	if (GameRules_GetProp("m_bInWaitingForPlayers"))
+		return;
+	
 	int client = GetClientOfUserId(event.GetInt("userid"));
 	if (TF2_GetClientTeam(client) <= TFTeam_Spectator)
 		return;
@@ -165,6 +168,9 @@ public Action Event_PlayerSpawn(Event event, const char[] name, bool dontBroadca
 
 public Action Event_FishNotice(Event event, const char[] name, bool dontBroadcast)
 {
+	if (GameRules_GetProp("m_bInWaitingForPlayers"))
+		return;
+	
 	int victim = GetClientOfUserId(event.GetInt("userid"));
 	int attacker = GetClientOfUserId(event.GetInt("attacker"));
 	int assister = GetClientOfUserId(event.GetInt("assister"));
@@ -181,6 +187,9 @@ public Action Event_FishNotice(Event event, const char[] name, bool dontBroadcas
 
 public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadcast)
 {
+	if (GameRules_GetProp("m_bInWaitingForPlayers"))
+		return;
+	
 	int victim = GetClientOfUserId(event.GetInt("userid"));
 	int attacker = GetClientOfUserId(event.GetInt("attacker"));
 	int assister = GetClientOfUserId(event.GetInt("assister"));
@@ -274,6 +283,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 
 public Action Event_ObjectDestroyed(Event event, const char[] name, bool dontBroadcast)
 {
+	if (GameRules_GetProp("m_bInWaitingForPlayers"))
+		return;
+	
 	int victim = GetClientOfUserId(event.GetInt("userid"));
 	int attacker = GetClientOfUserId(event.GetInt("attacker"));
 	int assister = GetClientOfUserId(event.GetInt("assister"));

--- a/addons/sourcemod/scripting/royale/loot/loot.sp
+++ b/addons/sourcemod/scripting/royale/loot/loot.sp
@@ -10,33 +10,33 @@ void Loot_Init()
 	g_LootTypeMap.SetValue("item_powerup", Loot_Item_Powerup);
 }
 
+void Loot_OnEntitySpawned(int entity)
+{
+	char targetname[CONFIG_MAXCHAR];
+	GetEntPropString(entity, Prop_Data, "m_iName", targetname, sizeof(targetname));
+	
+	LootCrate loot;
+	if (StrEqual(targetname, "fr_crate"))
+		LootCrate_GetDefault(loot);
+	else if (!LootConfig_GetPrefabByTargetname(targetname, loot))
+		return;
+	
+	
+	if (!GameRules_GetProp("m_bInWaitingForPlayers") && GetRandomFloat() <= float(GetPlayerCount()) / float(TF_MAXPLAYERS))
+	{
+		SetEntProp(entity, Prop_Data, "m_iMaxHealth", loot.health);
+		SetEntProp(entity, Prop_Data, "m_iHealth", loot.health);
+		SetEntProp(entity, Prop_Data, "m_takedamage", DAMAGE_YES);
+		HookSingleEntityOutput(entity, "OnBreak", EntityOutput_OnBreakCrateTargetname, true);
+	}
+	else
+	{
+		RemoveEntity(entity);
+	}
+}
+
 void Loot_SetupFinished()
 {
-	int crate = -1;
-	while ((crate = FindEntityByClassname(crate, "prop_dynamic*")) != -1)
-	{
-		char targetname[CONFIG_MAXCHAR];
-		GetEntPropString(crate, Prop_Data, "m_iName", targetname, sizeof(targetname));
-		
-		LootCrate loot;
-		if (StrEqual(targetname, "fr_crate"))
-			LootCrate_GetDefault(loot);
-		else if (!LootConfig_GetPrefabByTargetname(targetname, loot))
-			continue;
-		
-		if (GetRandomFloat() <= float(GetPlayerCount()) / float(TF_MAXPLAYERS))
-		{
-			SetEntProp(crate, Prop_Data, "m_iMaxHealth", loot.health);
-			SetEntProp(crate, Prop_Data, "m_iHealth", loot.health);
-			SetEntProp(crate, Prop_Data, "m_takedamage", DAMAGE_YES);
-			HookSingleEntityOutput(crate, "OnBreak", EntityOutput_OnBreakCrateTargetname, true);
-		}
-		else
-		{
-			RemoveEntity(crate);
-		}
-	}
-	
 	int pos;
 	LootCrate loot;
 	while (LootConfig_GetCrate(pos, loot))

--- a/addons/sourcemod/scripting/royale/sdkhook.sp
+++ b/addons/sourcemod/scripting/royale/sdkhook.sp
@@ -68,7 +68,11 @@ void SDKHook_OnEntityCreated(int entity, const char[] classname)
 	}
 	else if (StrContains(classname, "prop_physics") == 0)
 	{
-		SDKHook(entity, SDKHook_Spawn, Prop_Spawn);
+		SDKHook(entity, SDKHook_Spawn, PropPhysics_Spawn);
+	}
+	else if (StrContains(classname, "prop_dynamic") == 0)
+	{
+		SDKHook(entity, SDKHook_Spawn, PropDynamic_Spawn);
 	}
 	else if (StrEqual(classname, "obj_dispenser"))
 	{
@@ -395,9 +399,14 @@ public void Projectile_TouchPost(int entity, int other)
 	}
 }
 
-public Action Prop_Spawn(int prop)
+public Action PropPhysics_Spawn(int prop)
 {
 	Vehicles_OnEntitySpawned(prop);
+}
+
+public Action PropDynamic_Spawn(int prop)
+{
+	Loot_OnEntitySpawned(prop);
 }
 
 public Action Dispenser_StartTouch(int dispenser, int toucher)

--- a/addons/sourcemod/scripting/royale/sdkhook.sp
+++ b/addons/sourcemod/scripting/royale/sdkhook.sp
@@ -72,7 +72,7 @@ void SDKHook_OnEntityCreated(int entity, const char[] classname)
 	}
 	else if (StrContains(classname, "prop_dynamic") == 0)
 	{
-		SDKHook(entity, SDKHook_Spawn, PropDynamic_Spawn);
+		SDKHook(entity, SDKHook_SpawnPost, PropDynamic_SpawnPost);
 	}
 	else if (StrEqual(classname, "obj_dispenser"))
 	{
@@ -404,7 +404,7 @@ public Action PropPhysics_Spawn(int prop)
 	Vehicles_OnEntitySpawned(prop);
 }
 
-public Action PropDynamic_Spawn(int prop)
+public Action PropDynamic_SpawnPost(int prop)
 {
 	Loot_OnEntitySpawned(prop);
 }

--- a/addons/sourcemod/scripting/royale/stocks.sp
+++ b/addons/sourcemod/scripting/royale/stocks.sp
@@ -593,6 +593,9 @@ stock Action TF2_OnGiveNamedItem(int client, const char[] classname, int index)
 	if (g_SkipGiveNamedItem)
 		return Plugin_Continue;
 	
+	if (GameRules_GetProp("m_bInWaitingForPlayers"))
+		return Plugin_Continue;
+	
 	//Allow keep spellbook
 	if (StrEqual(classname, "tf_weapon_spellbook"))
 		return Plugin_Continue;

--- a/addons/sourcemod/scripting/royale/vehicles/vehicles.sp
+++ b/addons/sourcemod/scripting/royale/vehicles/vehicles.sp
@@ -341,15 +341,22 @@ void Vehicles_OnEntitySpawned(int entity)
 	else if (!VehiclesConfig_GetByTargetname(targetname, vehicle))
 		return;
 	
-	vehicle.Create(EntIndexToEntRef(entity));
-	
-	DispatchKeyValueFloat(entity, "massScale", vehicle.mass);
-	DispatchKeyValueFloat(entity, "physdamagescale", vehicle.impact);
-	
-	SetEntProp(entity, Prop_Send, "m_nSolidType", SOLID_VPHYSICS);
-	SetEntProp(entity, Prop_Data, "m_takedamage", DAMAGE_NO);
-	
-	g_VehiclesEntity.PushArray(vehicle);
+	if (!GameRules_GetProp("m_bInWaitingForPlayers"))
+	{
+		vehicle.Create(EntIndexToEntRef(entity));
+		
+		DispatchKeyValueFloat(entity, "massScale", vehicle.mass);
+		DispatchKeyValueFloat(entity, "physdamagescale", vehicle.impact);
+		
+		SetEntProp(entity, Prop_Send, "m_nSolidType", SOLID_VPHYSICS);
+		SetEntProp(entity, Prop_Data, "m_takedamage", DAMAGE_NO);
+		
+		g_VehiclesEntity.PushArray(vehicle);
+	}
+	else
+	{
+		RemoveEntity(entity);
+	}
 }
 
 void Vehicles_OnEntityDestroyed(int entity)


### PR DESCRIPTION
Allows players to spawn into the game during the "Waiting for players" period to have a short deathmatch before the game begins.
Players spawn with their regular TF2 loadout in BLU and have instant respawn.