### PR TITLE
Fix parachute not deploying

### DIFF
--- a/addons/sourcemod/scripting/royale.sp
+++ b/addons/sourcemod/scripting/royale.sp
@@ -714,6 +714,9 @@ public void TF2_OnConditionAdded(int client, TFCond condition)
 	if (!g_Enabled)
 		return;
 	
+	if (condition == TFCond_Parachute)
+		PrintHintText(client, "%t", "BattleBus_ParachuteDeployed");
+	
 	//Dont give uber on spawn from mannpower
 	if (condition == TFCond_UberchargedCanteen && FRPlayer(client).PlayerState == PlayerState_Parachute)
 		TF2_RemoveCondition(client, TFCond_UberchargedCanteen);

--- a/addons/sourcemod/scripting/royale.sp
+++ b/addons/sourcemod/scripting/royale.sp
@@ -718,7 +718,7 @@ public void TF2_OnConditionAdded(int client, TFCond condition)
 	if (condition == TFCond_Parachute)
 		PrintHintText(client, "%t", "BattleBus_ParachuteDeployed");
 	
-	//Dont give uber on spawn from mannpower
+	//Don't give uber on spawn from Mannpower
 	if (condition == TFCond_UberchargedCanteen && FRPlayer(client).PlayerState == PlayerState_Parachute)
 		TF2_RemoveCondition(client, TFCond_UberchargedCanteen);
 	

--- a/addons/sourcemod/scripting/royale/battlebus.sp
+++ b/addons/sourcemod/scripting/royale/battlebus.sp
@@ -272,6 +272,7 @@ public Action Timer_SecToDeployParachute(Handle timer, int serial)
 			{
 				TF2_AddCondition(client, TFCond_Parachute);
 				PrintHintText(client, "%t", "BattleBus_ParachuteDeployed");
+				CreateTimer(1.0, Timer_SecToDeployParachute, serial);
 			}
 		}
 		else

--- a/addons/sourcemod/scripting/royale/battlebus.sp
+++ b/addons/sourcemod/scripting/royale/battlebus.sp
@@ -262,9 +262,9 @@ public Action Timer_SecToDeployParachute(Handle timer, int serial)
 	{
 		if (FRPlayer(client).PlayerState == PlayerState_Parachute && !TF2_IsPlayerInCondition(client, TFCond_Parachute))
 		{
+			FRPlayer(client).SecToDeployParachute--;
 			if (FRPlayer(client).SecToDeployParachute > 0)
 			{
-				FRPlayer(client).SecToDeployParachute--;
 				PrintHintText(client, "%t", "BattleBus_SecToDeployParachute", FRPlayer(client).SecToDeployParachute);
 				CreateTimer(1.0, Timer_SecToDeployParachute, serial);
 			}

--- a/addons/sourcemod/scripting/royale/battlebus.sp
+++ b/addons/sourcemod/scripting/royale/battlebus.sp
@@ -272,7 +272,7 @@ public Action Timer_SecToDeployParachute(Handle timer, int serial)
 			{
 				TF2_AddCondition(client, TFCond_Parachute);
 				PrintHintText(client, "%t", "BattleBus_ParachuteDeployed");
-				CreateTimer(1.0, Timer_SecToDeployParachute, serial);
+				CreateTimer(0.1, Timer_SecToDeployParachute, serial);
 			}
 		}
 		else

--- a/addons/sourcemod/scripting/royale/battlebus.sp
+++ b/addons/sourcemod/scripting/royale/battlebus.sp
@@ -271,14 +271,12 @@ public Action Timer_SecToDeployParachute(Handle timer, int serial)
 			else
 			{
 				TF2_AddCondition(client, TFCond_Parachute);
-				PrintHintText(client, "%t", "BattleBus_ParachuteDeployed");
 				CreateTimer(0.1, Timer_SecToDeployParachute, serial);
 			}
 		}
 		else
 		{
 			FRPlayer(client).SecToDeployParachute = 0;
-			PrintHintText(client, "%t", "BattleBus_ParachuteDeployed");
 		}
 	}
 }

--- a/addons/sourcemod/scripting/royale/battlebus.sp
+++ b/addons/sourcemod/scripting/royale/battlebus.sp
@@ -262,9 +262,9 @@ public Action Timer_SecToDeployParachute(Handle timer, int serial)
 	{
 		if (FRPlayer(client).PlayerState == PlayerState_Parachute && !TF2_IsPlayerInCondition(client, TFCond_Parachute))
 		{
-			FRPlayer(client).SecToDeployParachute--;
 			if (FRPlayer(client).SecToDeployParachute > 0)
 			{
+				FRPlayer(client).SecToDeployParachute--;
 				PrintHintText(client, "%t", "BattleBus_SecToDeployParachute", FRPlayer(client).SecToDeployParachute);
 				CreateTimer(1.0, Timer_SecToDeployParachute, serial);
 			}


### PR DESCRIPTION
When 2 players spawn at the same time, the player ontop will be considered touching ground and cannot deploy their parachute.

This causes the issue of the player being stuck in the _PlayerState_Parachute_ phase and cannot pickup weapons.

This fix retriggers the timer every 0.1 seconds if the player failed to deploy their parachute in time.