### PR TITLE
Fix map config name detection

### DIFF
--- a/addons/sourcemod/scripting/royale/config.sp
+++ b/addons/sourcemod/scripting/royale/config.sp
@@ -112,7 +112,7 @@ void Config_Save()
 }
 
 bool Config_GetMapFilepath(char[] filePath, int length)
-{	
+{
 	char mapName[PLATFORM_MAX_PATH];
 	GetCurrentMap(mapName, sizeof(mapName));
 	GetMapDisplayName(mapName, mapName, sizeof(mapName));

--- a/addons/sourcemod/scripting/royale/config.sp
+++ b/addons/sourcemod/scripting/royale/config.sp
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */ 
+ */
 
 void Config_Refresh()
 {

--- a/addons/sourcemod/scripting/royale/config.sp
+++ b/addons/sourcemod/scripting/royale/config.sp
@@ -13,8 +13,8 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
- 
+ */ 
+
 void Config_Refresh()
 {
 	g_PrecacheWeapon.Clear();
@@ -27,7 +27,8 @@ void Config_Refresh()
 	Config_ReadMapConfig(filePath);
 	
 	//Load map specific config
-	if(Config_GetMapFilepath(filePath, sizeof(filePath)))
+	filePath[0] = '\0';
+	if (Config_GetMapFilepath(filePath, sizeof(filePath)))
 		Config_ReadMapConfig(filePath);
 	
 	//Build filepath for list of loot tables
@@ -140,7 +141,7 @@ bool Config_GetMapFilepath(char[] filePath, int length)
 			strcopy(filePath, length, filePathBuffer);
 	}
 	
-	if(!FileExists(filePath))
+	if (!FileExists(filePath))
 	{
 		LogError("Configuration file for map could not be found at '%s.cfg'", tidyMapName);
 		return false;

--- a/addons/sourcemod/scripting/royale/config.sp
+++ b/addons/sourcemod/scripting/royale/config.sp
@@ -117,16 +117,35 @@ void Confg_GetMapFilepath(char[] filePath, int length)
 	GetCurrentMap(mapName, sizeof(mapName));
 	GetMapDisplayName(mapName, mapName, sizeof(mapName));
 	
+	int partsCount = CountCharInString(mapName, '_') + 1;
+	//The map has no prefix/suffix?
+	if (partsCount < 2)
+	{
+		BuildPath(Path_SM, filePath, length, "configs/royale/maps/%s.cfg", mapName);
+		return;
+	}
+	
 	//Split map prefix and first part of its name (e.g. pl_hightower)
-	char nameParts[2][PLATFORM_MAX_PATH];
-	ExplodeString(mapName, "_", nameParts, sizeof(nameParts), sizeof(nameParts[]));
+	char[][] nameParts = new char[partsCount][PLATFORM_MAX_PATH];
+	ExplodeString(mapName, "_", nameParts, partsCount, PLATFORM_MAX_PATH);
 	
-	//Stitch name parts together
+	//Start to stitch name parts together
 	char tidyMapName[PLATFORM_MAX_PATH];
-	Format(tidyMapName, sizeof(tidyMapName), "%s_%s", nameParts[0], nameParts[1]);
+	Format(tidyMapName, PLATFORM_MAX_PATH, "%s", nameParts[0]);
 	
-	//Build file path
-	BuildPath(Path_SM, filePath, length, "configs/royale/maps/%s.cfg", tidyMapName);
+	char filePathBuffer[PLATFORM_MAX_PATH];
+	
+	for (int i = 1; i < partsCount; i++)
+	{
+		Format(tidyMapName, sizeof(tidyMapName), "%s_%s", tidyMapName, nameParts[i]);
+		
+		//Build file path
+		BuildPath(Path_SM, filePathBuffer, length, "configs/royale/maps/%s.cfg", tidyMapName);
+		
+		//We are trying to find the most specific config
+		if (FileExists(filePathBuffer))
+			Format(filePath, PLATFORM_MAX_PATH, "%s", filePathBuffer);
+	}
 }
 
 bool Config_HasMapFilepath()

--- a/addons/sourcemod/scripting/royale/config.sp
+++ b/addons/sourcemod/scripting/royale/config.sp
@@ -132,6 +132,8 @@ void Confg_GetMapFilepath(char[] filePath, int length)
 	//Start to stitch name parts together
 	char tidyMapName[PLATFORM_MAX_PATH];
 	Format(tidyMapName, PLATFORM_MAX_PATH, "%s", nameParts[0]);
+	//Fail-safe
+	BuildPath(Path_SM, filePath, length, "configs/royale/maps/%s.cfg", tidyMapName);
 	
 	char filePathBuffer[PLATFORM_MAX_PATH];
 	

--- a/addons/sourcemod/scripting/royale/stocks.sp
+++ b/addons/sourcemod/scripting/royale/stocks.sp
@@ -1216,3 +1216,22 @@ public Action Glow_SetTransmit(int glow, int client)
 	
 	return Plugin_Handled;
 }
+
+/**
+ * Counts the number of occurences of a character in a string.
+ *
+ * @param string        String.
+ * @param letter            Character to count.
+ * @return            The number of occurences of the character in the string.
+ */
+
+stock int CountCharInString(const char[] string, char letter) 
+{
+	int i = 0, count = 0;
+	
+	while (string[i] != '\0') 
+		if (string[i++] == letter)
+			count++;
+	
+	return count;
+} 

--- a/addons/sourcemod/scripting/royale/stocks.sp
+++ b/addons/sourcemod/scripting/royale/stocks.sp
@@ -1217,17 +1217,9 @@ public Action Glow_SetTransmit(int glow, int client)
 	return Plugin_Handled;
 }
 
-/**
- * Counts the number of occurences of a character in a string.
- *
- * @param string        String.
- * @param letter            Character to count.
- * @return            The number of occurences of the character in the string.
- */
-
 stock int CountCharInString(const char[] string, char letter) 
 {
-	int i = 0, count = 0;
+	int i, count;
 	
 	while (string[i] != '\0') 
 		if (string[i++] == letter)


### PR DESCRIPTION
Fixes config detection for maps with multiple _ in their name for maps such as br_slider_shore